### PR TITLE
Issue #5: CLAUDE.mdを追加してClaude Codeのカスタム命令を設定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# Mynion Project Rules
+
+## Git & Issue Management
+- Git操作は必ずGitHub MCPを使用する（bash gitコマンドは使わない）
+- 機能追加やバグ修正を始める前に、GitHub Issueを作成する
+- 作業時は `git worktree` を使用してブランチごとに別ディレクトリで作業する
+- コミットメッセージにはIssue番号を含める（例: "Issue #3: カレンダーMCP追加"）
+- コミットメッセージにClaudeの署名（Co-Authored-By等）は含めない
+- PRを作成する際は変更内容を明確に記載する
+
+## MCP Usage
+- 利用可能なMCPサーバー: github, filesystem, aws-documentation, cdk-mcp-server, amazon-bedrock-agentcore-mcp-server
+- ファイル操作はfilesystem MCPを優先使用
+- GitHub操作（issue, PR, code search等）はgithub MCPを使用
+- AWSドキュメント参照はaws-documentation MCPを使用
+
+## Development Workflow
+- Python 3.11+ を使用
+- パッケージ管理は uv を使用
+- コミット前に `ruff check` を実行
+- 型チェックは `mypy` で実施
+
+## Project Structure
+- `cdk/` - AWS CDKインフラストラクチャコード
+- `app/` - アプリケーションコード（Slack連携等）
+- `mcp/` - MCPサーバー実装
+- `agent.py` - Strands Agentのメイン実装
+
+## Technology Stack
+- AWS CDK (Python) for infrastructure
+- Strands Agents (Bedrock AgentCore)
+- Slack Bolt for Slack integration
+- Google Calendar API for calendar features
+- FastAPI + Uvicorn for API server


### PR DESCRIPTION
## Summary
- CLAUDE.mdファイルを追加し、Claude Codeに常に守ってほしいルールを設定
- 毎回指示しなくても自動的にルールが適用されるようになる

## 含まれるルール
- Git操作はGitHub MCPを使用
- 作業前にIssue作成
- git worktreeを使用してブランチごとに別ディレクトリで作業
- コミットメッセージにIssue番号を含める
- コミットメッセージにClaudeの署名は含めない
- 利用可能なMCPサーバーの用途
- 開発ワークフロー（ruff, mypy, uv）
- プロジェクト構造とTech Stack

Closes #5