### PR TITLE
Issue #12: CDK Slackワーカーのパス修正

### DIFF
--- a/cdk/slack_stack.py
+++ b/cdk/slack_stack.py
@@ -95,7 +95,7 @@ class SlackIntegrationStack(Stack):
             Lambda function
         """
         # Get worker directory
-        worker_dir = Path(__file__).parent.parent / "app" / "slack" / "worker"
+        worker_dir = Path(__file__).parent.parent / "interfaces" / "slack" / "worker"
 
         # Create execution role for Worker Lambda
         worker_role = iam.Role(
@@ -175,7 +175,7 @@ class SlackIntegrationStack(Stack):
             Lambda function
         """
         # Get receiver code path
-        receiver_dir = Path(__file__).parent.parent / "app" / "slack"
+        receiver_dir = Path(__file__).parent.parent / "interfaces" / "slack"
 
         # Create execution role for Receiver Lambda
         receiver_role = iam.Role(


### PR DESCRIPTION
## Summary
- CDKスタック内のSlackワーカーパス参照を `app/slack` から `interfaces/slack` に修正

## 変更内容
- `cdk/slack_stack.py`: ワーカーとレシーバーのディレクトリパスを更新

## Test plan
- [x] `cdk deploy --all` でデプロイ成功を確認済み

Closes #12