### PR TITLE
Issue #17: スレッド内返信でメンションなしでも反応するよう改善

### DIFF
--- a/interfaces/slack/receiver.py
+++ b/interfaces/slack/receiver.py
@@ -14,6 +14,7 @@ import time
 from typing import Any
 
 import boto3
+import httpx
 
 # Configure logging
 logger = logging.getLogger()
@@ -29,6 +30,9 @@ WORKER_LAMBDA_ARN = os.environ.get("WORKER_LAMBDA_ARN", "")
 
 # Cache for Slack credentials (loaded once per container lifecycle)
 _slack_credentials: dict[str, str] | None = None
+
+# Cache for bot user ID (loaded once per container lifecycle)
+_bot_user_id: str | None = None
 
 
 def get_slack_credentials() -> dict[str, str]:
@@ -59,6 +63,179 @@ def get_slack_credentials() -> dict[str, str]:
             "SLACK_BOT_TOKEN": os.environ.get("SLACK_BOT_TOKEN", ""),
             "SLACK_SIGNING_SECRET": os.environ.get("SLACK_SIGNING_SECRET", ""),
         }
+
+
+class SlackClient:
+    """Minimal Slack client for response filtering in receiver."""
+
+    def __init__(self, bot_token: str):
+        self.bot_token = bot_token
+        self.base_url = "https://slack.com/api"
+
+    def get_bot_user_id(self) -> str:
+        """
+        Get the bot's user ID using auth.test API.
+
+        Results are cached globally for the container lifecycle.
+        Only successful results are cached.
+
+        Returns:
+            Bot user ID
+
+        Raises:
+            RuntimeError: When the bot user ID cannot be retrieved
+        """
+        global _bot_user_id
+
+        # Return cached value if available
+        if _bot_user_id is not None:
+            return _bot_user_id
+
+        try:
+            with httpx.Client() as client:
+                response = client.post(
+                    f"{self.base_url}/auth.test",
+                    headers={
+                        "Authorization": f"Bearer {self.bot_token}",
+                        "Content-Type": "application/json",
+                    },
+                    timeout=10.0,
+                )
+
+                response.raise_for_status()
+                result: dict[str, Any] = response.json()
+
+                if not result.get("ok"):
+                    error_msg = f"Slack API error: {result.get('error')}"
+                    logger.error(error_msg)
+                    raise RuntimeError(error_msg)
+
+                user_id: str = result.get("user_id", "")
+                if not user_id:
+                    error_msg = "Slack API response missing user_id"
+                    logger.error(error_msg)
+                    raise RuntimeError(error_msg)
+
+                # Cache successful result
+                _bot_user_id = user_id
+                return user_id
+
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting bot user ID: {str(e)}", exc_info=True)
+            raise RuntimeError(f"Failed to get bot user ID: {str(e)}") from e
+
+    def get_thread_replies(self, channel: str, thread_ts: str) -> dict[str, Any]:
+        """
+        Get recent replies in a thread using conversations.replies API.
+
+        Retrieves up to 5 most recent messages to check bot participation.
+        This limit balances API performance with detection accuracy for
+        typical conversation threads.
+
+        Args:
+            channel: Slack channel ID
+            thread_ts: Thread timestamp (parent message ts)
+
+        Returns:
+            Slack API response with messages.
+            Returns {"messages": []} on error to allow graceful degradation.
+        """
+        try:
+            with httpx.Client() as client:
+                response = client.get(
+                    f"{self.base_url}/conversations.replies",
+                    headers={
+                        "Authorization": f"Bearer {self.bot_token}",
+                    },
+                    params={
+                        "channel": channel,
+                        "ts": thread_ts,
+                        "limit": 5,
+                    },
+                    timeout=10.0,
+                )
+
+                response.raise_for_status()
+                result: dict[str, Any] = response.json()
+
+                if not result.get("ok"):
+                    logger.error(f"Slack API error: {result.get('error')}")
+                    return {"messages": []}
+
+                return result
+
+        except Exception as e:
+            logger.error(f"Error getting thread replies: {str(e)}", exc_info=True)
+            return {"messages": []}
+
+
+def is_bot_in_thread(
+    slack_client: SlackClient, channel: str, thread_ts: str, bot_user_id: str
+) -> bool:
+    """
+    Check if the bot has participated in the thread.
+
+    Args:
+        slack_client: SlackClient instance
+        channel: Slack channel ID
+        thread_ts: Thread timestamp
+        bot_user_id: Bot's user ID
+
+    Returns:
+        True if the bot has messages in the thread.
+        False if the bot has no messages in the thread or if an error occurs
+        while checking (errors are logged and not raised).
+    """
+    try:
+        response = slack_client.get_thread_replies(channel, thread_ts)
+        messages = response.get("messages", [])
+
+        return any(msg.get("user") == bot_user_id for msg in messages)
+    except Exception as e:
+        logger.error(f"Error checking bot in thread: {str(e)}", exc_info=True)
+        return False
+
+
+def should_respond(
+    slack_client: SlackClient,
+    slack_event: dict[str, Any],
+    bot_user_id: str,
+) -> bool:
+    """
+    Determine if the bot should respond to this event.
+
+    The bot responds when:
+    - The bot is mentioned in the message text
+    - The message is a reply in a thread where the bot has previously participated
+
+    Args:
+        slack_client: SlackClient instance
+        slack_event: Slack event data
+        bot_user_id: Bot's user ID
+
+    Returns:
+        True if bot should respond, False otherwise
+    """
+    text = slack_event.get("text", "")
+    thread_ts = slack_event.get("thread_ts")
+    channel = slack_event.get("channel", "")
+
+    # Ignore messages from the bot itself (prevents infinite loop)
+    if slack_event.get("user") == bot_user_id:
+        return False
+
+    # Ignore messages with bot_id (other bots)
+    if slack_event.get("bot_id"):
+        return False
+
+    # Respond if mentioned
+    if f"<@{bot_user_id}>" in text:
+        return True
+
+    # For thread replies, check if bot is participating
+    return bool(thread_ts and is_bot_in_thread(slack_client, channel, thread_ts, bot_user_id))
 
 
 def verify_slack_request(event: dict[str, Any]) -> bool:
@@ -168,9 +345,32 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
         if event_type == "event_callback":
             slack_event = body.get("event", {})
 
-            # Skip bot's own messages early to avoid unnecessary Worker invocation
-            if slack_event.get("bot_id"):
-                logger.info("Skipping bot's own message")
+            # Get Slack credentials for bot user ID check
+            credentials = get_slack_credentials()
+            slack_bot_token = credentials.get("SLACK_BOT_TOKEN", "")
+
+            if not slack_bot_token:
+                logger.error("SLACK_BOT_TOKEN not found, skipping response check")
+                return {
+                    "statusCode": 200,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": json.dumps({"ok": True}),
+                }
+
+            # Check if bot should respond to this event
+            slack_client = SlackClient(slack_bot_token)
+            try:
+                bot_user_id = slack_client.get_bot_user_id()
+            except RuntimeError as e:
+                logger.error(f"Failed to get bot user ID: {e}")
+                return {
+                    "statusCode": 200,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": json.dumps({"ok": True}),
+                }
+
+            if not should_respond(slack_client, slack_event, bot_user_id):
+                logger.info("Bot should not respond to this event, skipping")
                 return {
                     "statusCode": 200,
                     "headers": {"Content-Type": "application/json"},


### PR DESCRIPTION
## Summary

ボットが参加しているスレッド内の返信であれば、メンションなしでも反応するように改善しました。

### 変更点

- **SlackClientに新メソッド追加**
  - `get_bot_user_id()`: auth.test APIを使用してボットのユーザーIDを取得
  - `get_thread_replies()`: conversations.replies APIを使用してスレッド内のメッセージを取得

- **判定ロジック追加**
  - `is_bot_in_thread()`: スレッド内にボットのメッセージがあるか確認
  - `should_respond()`: ボットが反応すべきかを総合的に判定

- **最適化**
  - receiver.pyでbot_idフィルタリングを追加し、ボット自身のメッセージを早期スキップ

### 動作

| 状況 | 反応 |
|------|------|
| メンションあり（どこでも） | する |
| ボットが参加しているスレッド内返信（メンションなし） | する |
| ボットが参加していないスレッド内返信 | しない |
| 通常メッセージ（メンションなし） | しない |

## Test plan

- [ ] Slackアプリの設定で`message.channels`イベントを購読（手動設定必要）
- [ ] メンション付きメッセージでボットが反応することを確認
- [ ] ボットが参加しているスレッドでメンションなしで返信し、反応することを確認
- [ ] ボットが参加していないスレッドでメンションなしで返信し、反応しないことを確認
- [ ] 通常メッセージ（メンションなし）で反応しないことを確認

## 関連Issue

Closes #17