### PR TITLE
docs: update README with Google Calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,210 +1,156 @@
-# Mynion - Strands Agent on AWS Bedrock AgentCore
+# Mynion - Slack AI Assistant on AWS Bedrock AgentCore
 
-このプロジェクトは、Strands AgentをAWS Bedrock AgentCore Runtimeにデプロイするためのものです。
+SlackからGoogleカレンダーを操作できるAIアシスタント。AWS Bedrock AgentCoreとStrands Agentを使用。
+
+## 機能
+
+- **Slack連携**: メンションでAIアシスタントと対話
+- **Googleカレンダー統合**: 予定の取得・作成（OAuth認証）
+- **自然言語処理**: 日本語で予定を確認・登録
+
+## アーキテクチャ
+
+```
+┌─────────┐     ┌─────────────┐     ┌──────────────────┐
+│  Slack  │────▶│ API Gateway │────▶│ Receiver Lambda  │
+└─────────┘     └─────────────┘     └────────┬─────────┘
+                                              │ SQS
+                                              ▼
+┌─────────────────┐     ┌─────────────────────────────────┐
+│ Worker Lambda   │────▶│ AgentCore Runtime (Strands)     │
+└─────────────────┘     └────────────────┬────────────────┘
+                                         │ MCP
+                                         ▼
+                        ┌─────────────────────────────────┐
+                        │ AgentCore Gateway               │
+                        │ └── Calendar MCP Lambda         │
+                        └────────────────┬────────────────┘
+                                         │ OAuth
+                                         ▼
+                        ┌─────────────────────────────────┐
+                        │ Google Calendar API             │
+                        └─────────────────────────────────┘
+```
 
 ## プロジェクト構造
 
 ```
 mynion/
-├── agent.py                 # FastAPIベースのStrands Agentアプリケーション
-├── Dockerfile               # ARM64対応のDockerイメージ定義
-├── pyproject.toml           # Pythonプロジェクトの依存関係
-├── uv.lock                  # uvロックファイル
-└── cdk/                     # AWS CDKインフラストラクチャコード
-    ├── app.py               # CDKアプリケーションのエントリーポイント
-    ├── agentcore_runtime.py # AgentCore Runtimeスタック定義
-    ├── cdk.json             # CDK設定
-    └── requirements.txt     # CDK依存関係
+├── agent.py                          # Strands Agent (AgentCore Runtime)
+├── Dockerfile                        # Agent用Dockerイメージ
+├── pyproject.toml                    # Python依存関係
+├── cdk/                              # AWS CDKインフラ
+│   ├── app.py                        # CDKエントリーポイント
+│   ├── agentcore_runtime.py          # AgentCore Runtimeスタック
+│   ├── gateway_stack.py              # AgentCore Gatewayスタック
+│   ├── slack_stack.py                # Slack連携スタック
+│   ├── cdk.context.json.example      # コンテキスト設定例
+│   └── post-deploy.sh                # デプロイ後スクリプト
+├── interfaces/slack/                 # Slackインターフェース
+│   ├── receiver.py                   # イベント受信Lambda
+│   ├── worker/                       # ワーカーLambda
+│   └── oauth_callback/               # OAuthコールバックLambda
+├── mcp/calendar/                     # Calendar MCP
+│   └── handler.py                    # カレンダー操作ハンドラー
+└── docs/                             # ドキュメント
 ```
 
-## 前提条件
+## セットアップ
 
-1. **Python 3.11以上**
-2. **uv** (Pythonパッケージマネージャー)
-   ```bash
-   curl -LsSf https://astral.sh/uv/install.sh | sh
-   ```
+### 前提条件
 
-3. **Node.js** (CDK CLIに必要)
-4. **AWS CLI** (設定済み)
-   ```bash
-   aws configure
-   ```
+- Python 3.11+
+- [uv](https://astral.sh/uv) (パッケージマネージャー)
+- Node.js (CDK CLI用)
+- AWS CLI (設定済み)
+- Docker
 
-5. **AWS CDK CLI**
-   ```bash
-   npm install -g aws-cdk
-   ```
-
-6. **Docker** (ローカルテスト用)
-
-## 開発環境セットアップ
+### 1. 依存関係のインストール
 
 ```bash
-# 依存関係のインストール（dev依存含む）
 uv sync --dev
-
-# pre-commit hooksの有効化（初回のみ）
 uv run pre-commit install
 ```
 
-これにより、コミット時に自動でリンター（Ruff）と型チェック（mypy）が実行されます。
+### 2. Google OAuth設定
 
-## ローカルでのテスト
+1. [Google Cloud Console](https://console.cloud.google.com/)でOAuthクライアントを作成
+2. AWS Bedrock AgentCoreでCredential Providerを設定
+3. `cdk/cdk.context.json`を作成:
 
-デプロイ前にローカルでエージェントをテストできます：
+```json
+{
+  "mynion:googleCredentialProvider": "YourCredentialProviderName",
+  "mynion:googleOauthCallbackUrl": "https://your-callback-url"
+}
+```
+
+### 3. Slack App設定
+
+1. [Slack API](https://api.slack.com/apps)でAppを作成
+2. Bot Token Scopesを設定: `chat:write`, `app_mentions:read`
+3. Event SubscriptionsでRequest URLを設定
+4. AWS Secrets Managerに認証情報を保存
+
+### 4. デプロイ
 
 ```bash
-# 依存関係のインストール
-uv sync
+cd cdk
 
-# アプリケーションの起動
+# 初回のみ
+cdk bootstrap aws://ACCOUNT-ID/ap-northeast-1
+
+# デプロイ
+cdk deploy --all
+
+# OAuth callback URL設定（デプロイ後）
+./post-deploy.sh
+```
+
+## 使い方
+
+Slackでボットをメンションして話しかけます：
+
+```
+@mynion 明日の予定は？
+@mynion 来週月曜の10時から11時に会議を入れて
+```
+
+初回利用時はGoogle認証が必要です。表示されるリンクから認証を完了してください。
+
+## 開発
+
+### ローカルテスト
+
+```bash
+# Agentのテスト
 uv run uvicorn agent:app --host 0.0.0.0 --port 8080
 
-# 別のターミナルでテスト
-# /pingエンドポイント
-curl http://localhost:8080/ping
-
-# /invocationsエンドポイント
 curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
-  -d '{
-    "input": {"prompt": "人工知能とは何ですか？"}
-  }'
+  -d '{"input": {"prompt": "こんにちは"}}'
 ```
 
-## AWSへのデプロイ
-
-### 1. AWS認証情報の設定
+### コード品質
 
 ```bash
-export AWS_ACCESS_KEY_ID="your-access-key"
-export AWS_SECRET_ACCESS_KEY="your-secret-key"
-export AWS_REGION="ap-northeast-1"
-```
+# リント・フォーマット
+uv run ruff check --fix .
+uv run ruff format .
 
-### 2. CDK Bootstrap（初回のみ）
-
-CDKを初めて使用するAWSアカウント/リージョンの場合、bootstrapが必要です：
-
-```bash
-cd cdk
-cdk bootstrap aws://ACCOUNT-ID/ap-northeast-1
-```
-
-### 3. CDK依存関係のインストール
-
-```bash
-cd cdk
-uv pip install --prerelease=allow -r requirements.txt
-```
-
-注：`aws-cdk-aws-bedrock-agentcore-alpha`はalphaパッケージなので、`--prerelease=allow`フラグが必要です。
-
-### 4. CDKスタックのシンセサイズ
-
-CloudFormationテンプレートを生成して確認：
-
-```bash
-cdk synth
-```
-
-### 5. デプロイ
-
-```bash
-cdk deploy
-```
-
-デプロイには数分かかります。以下の処理が行われます：
-- Dockerイメージのビルド（ARM64対応）
-- ECRリポジトリの作成とイメージのプッシュ
-- IAM実行ロールの作成（Bedrockモデルへのアクセス権限付き）
-- AgentCore Runtimeの作成
-- Productionエンドポイントの作成
-
-### 6. デプロイ完了後の情報確認
-
-デプロイが完了すると、以下の情報が出力されます：
-- Runtime ARN
-- Endpoint ARN
-
-これらの情報を使ってエージェントを呼び出すことができます。
-
-## エージェントの呼び出し
-
-デプロイ後、以下のようにエージェントを呼び出すことができます：
-
-```python
-import boto3
-import json
-
-# クライアントの作成
-client = boto3.client('bedrock-agentcore', region_name='ap-northeast-1')
-
-# エージェントの呼び出し
-payload = json.dumps({
-    "input": {"prompt": "機械学習を簡単に説明してください"}
-})
-
-response = client.invoke_agent_runtime(
-    agentRuntimeArn='<YOUR_RUNTIME_ARN>',  # cdk deployの出力から取得
-    runtimeSessionId='unique-session-id-at-least-33-characters-long',
-    payload=payload,
-    qualifier="production"  # または "DEFAULT"
-)
-
-# レスポンスの読み取り
-response_body = response['response'].read()
-response_data = json.loads(response_body)
-print("Agent Response:", response_data)
+# 型チェック
+uv run mypy .
 ```
 
 ## スタックの削除
 
-リソースを削除する場合：
-
 ```bash
 cd cdk
-cdk destroy
+cdk destroy --all
 ```
-
-## アーキテクチャ
-
-このプロジェクトは以下のAWSリソースを使用します：
-
-1. **Amazon ECR**: Dockerイメージのストレージ
-2. **AWS Bedrock AgentCore Runtime**: エージェントの実行環境
-3. **IAM Role**: AgentCore Runtimeの実行ロール（Bedrockモデルへのアクセス権限付き）
-4. **Runtime Endpoints**: エージェントへのアクセスポイント
-
-## セキュリティのベストプラクティス
-
-- IAMロールは最小権限の原則に従っています
-- Bedrockモデルへのアクセスは必要な操作のみに制限できます（`cdk/agentcore_runtime.py`の`resources`を編集）
-- VPCデプロイも可能です（`RuntimeNetworkConfiguration.using_vpc()`を使用）
-
-## トラブルシューティング
-
-### Docker BuildXが利用できない
-
-```bash
-docker buildx create --use
-```
-
-### CDK Bootstrapエラー
-
-AWS CLIの認証情報が正しく設定されているか確認してください：
-
-```bash
-aws sts get-caller-identity
-```
-
-### デプロイ中のタイムアウト
-
-Dockerイメージのビルドとプッシュには時間がかかる場合があります。初回デプロイは特に時間がかかることがあります。
 
 ## 参考リンク
 
 - [AWS Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/)
-- [AWS CDK Python Documentation](https://docs.aws.amazon.com/cdk/api/v2/python/)
-- [Strands Agents Documentation](https://pypi.org/project/strands-agents/)
+- [Strands Agents](https://pypi.org/project/strands-agents/)
+- [Slack Bolt for Python](https://slack.dev/bolt-python/)

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ uv run pre-commit install
 
 ```json
 {
-  "mynion:googleCredentialProvider": "YourCredentialProviderName",
-  "mynion:googleOauthCallbackUrl": "https://your-callback-url"
+  "mynion:googleCredentialProvider": "YourGoogleCredentialProviderName",
+  "mynion:googleOauthCallbackUrl": "https://bedrock-agentcore.ap-northeast-1.amazonaws.com/identities/oauth2/callback/your-callback-id"
 }
 ```
 


### PR DESCRIPTION
## Summary
READMEをGoogle Calendar統合後の最新状態に更新

### 変更内容
- プロジェクト概要をSlack AIアシスタントとして更新
- アーキテクチャ図を追加（Slack → AgentCore → Calendar MCP → Google API）
- プロジェクト構造を最新化（gateway_stack, oauth_callback, mcp/calendar等）
- セットアップ手順を更新（Google OAuth, Slack App設定）
- 使い方セクションを追加

## Test plan
- [ ] READMEの内容が正確であることを確認